### PR TITLE
Add required to validation of recaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following line to the `require` section of `composer.json`:
 ```php
     $rules = array(
         // ...
-        'recaptcha_response_field' => 'recaptcha',
+        'recaptcha_response_field' => 'required|recaptcha',
     };
 ```
 


### PR DESCRIPTION
Add required, otherwise if you don't enter a value for recaptcha it will pass validation, counter to the intentions of recaptcha.
