### PR TITLE
Config path for private_key was invalid, fixed

### DIFF
--- a/src/Greggilbert/Recaptcha/CheckRecaptchaV2.php
+++ b/src/Greggilbert/Recaptcha/CheckRecaptchaV2.php
@@ -17,7 +17,7 @@ class CheckRecaptchaV2
 	public function check($challenge, $response)
 	{
 		$parameters = http_build_query(array(
-			'secret'	=> app('config')->get('recaptcha::private_key'),
+			'secret'	=> app('config')->get('recaptcha::config.private_key'),
 			'remoteip'		=> app('request')->getClientIp(),
 			'challenge'		=> $challenge,
 			'response' => $response,


### PR DESCRIPTION
The private key config was set to:
 recaptcha::private_key
changed to:
 recaptcha::config.private_key
