### PR TITLE
Fix get config bug

### DIFF
--- a/src/Service/CheckRecaptchaV2.php
+++ b/src/Service/CheckRecaptchaV2.php
@@ -26,12 +26,12 @@ class CheckRecaptchaV2 implements RecaptchaInterface
         $checkResponse = null;
         
         // prefer curl, but fall back to file_get_contents
-        if('curl' === app('config')->get('recaptcha::config.driver') && function_exists('curl_version'))
+        if('curl' === app('config')->get('recaptcha.driver') && function_exists('curl_version'))
         {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_HEADER, false);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($curl, CURLOPT_TIMEOUT, app('config')->get('recaptcha::config.options.curl_timeout', 1));
+            curl_setopt($curl, CURLOPT_TIMEOUT, app('config')->get('recaptcha.options.curl_timeout', 1));
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 
             $checkResponse = curl_exec($curl);


### PR DESCRIPTION
The return value from 'recaptcha::config.driver' and 'recaptcha::config.options.curl_timeout' will always be null.