### PR TITLE
Fix the spaces with no script tag

### DIFF
--- a/src/views/captchav2.blade.php
+++ b/src/views/captchav2.blade.php
@@ -32,8 +32,7 @@ if ( ! function_exists('renderDataAttributes')) {
         <textarea id="g-recaptcha-response" name="g-recaptcha-response"
                   class="g-recaptcha-response"
                   style="width: 250px; height: 80px; border: 1px solid #c1c1c1;
-                         margin: 0; padding: 0; resize: none;">
-        </textarea>
+                         margin: 0; padding: 0; resize: none;"></textarea>
             </div>
         </div>
     </div>


### PR DESCRIPTION
When you use the noscript tag, there are spaces into the textarea because of the line return.