### PR TITLE
Allow private & public key config value to be a Closure

### DIFF
--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -30,7 +30,7 @@ class Recaptcha
         $mergedOptions = array_merge($this->config['options'], $options);
 
         $data = [
-            'public_key' => $this->config['public_key'],
+            'public_key' => value($this->config['public_key']),
             'options'    => $mergedOptions,
             'dataParams' => $this->extractDataParams($mergedOptions),
         ];

--- a/src/Service/CheckRecaptcha.php
+++ b/src/Service/CheckRecaptcha.php
@@ -24,7 +24,7 @@ class CheckRecaptcha implements RecaptchaInterface
     public function check($challenge, $response)
     {
         $parameters = http_build_query([
-            'privatekey' => app('config')->get('recaptcha.private_key'),
+            'privatekey' => value(app('config')->get('recaptcha.private_key')),
             'remoteip'   => app('request')->getClientIp(),
             'challenge'  => $challenge,
             'response'   => $response,

--- a/src/Service/CheckRecaptchaV2.php
+++ b/src/Service/CheckRecaptchaV2.php
@@ -19,7 +19,7 @@ class CheckRecaptchaV2 implements RecaptchaInterface
     public function check($challenge, $response)
     {
         $parameters = http_build_query([
-            'secret'   => app('config')->get('recaptcha.private_key'),
+            'secret'   => value(app('config')->get('recaptcha.private_key')),
             'remoteip' => app('request')->getClientIp(),
             'response' => $response,
         ]);


### PR DESCRIPTION
A Closure is needed to retrieve private_key or public_key stored in a database, for example.