### PR TITLE
Added the Secure Token option [#85]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ would default the language in all the reCAPTCHAs to Japanese. If you want to fur
 echo Recaptcha::render([ 'lang' => 'fr' ]);
 ```
 
-In order to use the [Secure Token](https://developers.google.com/recaptcha/docs/secure_token) you have to use the extra added option of Stoken. For example:
+In order to use the [Secure Token](https://developers.google.com/recaptcha/docs/secure_token) you have to use the extra added option of useSecureToken. For example:
 
 ```php
     // ...
     'options' => [
-		'useStoken' => 'true',
+		'useSecureToken' => true,
 	],
 ```
 
 would default the use of the secure token in all the reCAPTCHAs rendered elements. If you want to further customize, you can pass the options through the render option:
 
 ```php
-echo Recaptcha::render([ 'useStoken' => 'true' ]);
+echo Recaptcha::render([ 'useSecureToken' => true ]);
 ```
 
 Options passed into `Recaptcha::render` will always supercede the configuration.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ would default the language in all the reCAPTCHAs to Japanese. If you want to fur
 echo Recaptcha::render([ 'lang' => 'fr' ]);
 ```
 
-In order to use the [Secure Token](https://developers.google.com/recaptcha/docs/secure_token) you have to use the extra added option of Stoken i order to add the data-stoken field and iformation. For example:
+In order to use the [Secure Token](https://developers.google.com/recaptcha/docs/secure_token) you have to use the extra added option of Stoken. For example:
 
 ```php
     // ...

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It's also recommended to add `required` when validating.
 
 ## Customization
 
-reCAPTCHA v2 allows for customization of the widget through a number of options, listed [at the official documentation](https://developers.google.com/recaptcha/docs/display). You can configure the output of the captcha through six allowed keys: `theme`, `type`, `lang`, `callback`, `tabindex` and `expired-callback`.
+reCAPTCHA v2 allows for customization of the widget through a number of options, listed [at the official documentation](https://developers.google.com/recaptcha/docs/display). You can configure the output of the captcha through six allowed keys: `theme`, `type`, `lang`, `callback`, `tabindex`, `expired-callback` and `useStoke`.
 
 In the config file, you can create an `options` array to set the default behavior. For example:
 
@@ -81,6 +81,21 @@ would default the language in all the reCAPTCHAs to Japanese. If you want to fur
 
 ```php
 echo Recaptcha::render([ 'lang' => 'fr' ]);
+```
+
+In order to use the [Secure Token](https://developers.google.com/recaptcha/docs/secure_token) you have to use the extra added option of Stoken i order to add the data-stoken field and iformation. For example:
+
+```php
+    // ...
+    'options' => [
+		'useStoken' => 'true',
+	],
+```
+
+would default the use of the secure token in all the reCAPTCHAs rendered elements. If you want to further customize, you can pass the options through the render option:
+
+```php
+echo Recaptcha::render([ 'useStoken' => 'true' ]);
 ```
 
 Options passed into `Recaptcha::render` will always supercede the configuration.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~5.1",
-        "slushie/recaptcha-secure-token": "^1.1",
+        "slushie/recaptcha-secure-token": "^1.1"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1.1-dev"
+            "dev-master": "2.1-dev"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1-dev"
+            "dev-master": "2.1.1-dev"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "~5.1"
+        "illuminate/support": "~5.1",
+        "slushie/recaptcha-secure-token": "^1.1",
     },
     "autoload": {
         "classmap": [

--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -9,7 +9,7 @@ class Recaptcha
 
     protected $config = [ ];
 
-    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback', 'stoken' ];
+    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback', 'secure_token' ];
 
 
     public function __construct($service, $config)
@@ -39,10 +39,10 @@ class Recaptcha
             $data['lang'] = $mergedOptions['lang'];
         }
 
-        if(isset($mergedOptions['useStoken']) && $mergedOptions['useStoken'] === "true") {
+        if(isset($mergedOptions['useSecureToken']) && $mergedOptions['useSecureToken']) {
             $config = ['site_key' => $this->config['public_key'], 'site_secret' => $this->config['private_key']];
             $recaptchaToken = new \ReCaptchaSecureToken\ReCaptchaToken($config);
-            $data['stoken'] = $recaptchaToken->secureToken(str_random(40));
+            $data['secure_token'] = $recaptchaToken->secureToken(str_random(40));
         }
 
         $view = $this->getView($options);

--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -9,7 +9,7 @@ class Recaptcha
 
     protected $config = [ ];
 
-    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback' ];
+    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback', 'stoken' ];
 
 
     public function __construct($service, $config)
@@ -37,6 +37,12 @@ class Recaptcha
 
         if (array_key_exists('lang', $mergedOptions) && "" !== trim($mergedOptions['lang'])) {
             $data['lang'] = $mergedOptions['lang'];
+        }
+
+        if(isset($mergedOptions['useStoken']) && $mergedOptions['useStoken'] === "true") {
+            $config = ['site_key' => $this->config['public_key'], 'site_secret' => $this->config['private_key']];
+            $recaptchaToken = new \ReCaptchaSecureToken\ReCaptchaToken($config);
+            $data['stoken'] = $recaptchaToken->secureToken(str_random(40));
         }
 
         $view = $this->getView($options);

--- a/src/config/recaptcha.php
+++ b/src/config/recaptcha.php
@@ -47,8 +47,8 @@ return [
     */
     'options'     => [
 
-        'curl_timeout' => 1,
-
+        'curl_timeout'      => 1,
+        'useSecureToken'    => false,
     ],
 
     /*

--- a/src/views/captchav2.blade.php
+++ b/src/views/captchav2.blade.php
@@ -17,7 +17,7 @@ if ( ! function_exists('renderDataAttributes')) {
     </script>
 @endif
 <script src='https://www.google.com/recaptcha/api.js?render=onload{{ (isset($lang) ? '&hl='.$lang : '') }}'></script>
-<div class="g-recaptcha" data-sitekey="{{ $public_key }}" <?=renderDataAttributes($dataParams)?>></div>
+<div class="g-recaptcha" data-sitekey="{{ $public_key }}" <?=renderDataAttributes($dataParams)?> @if(!empty($stoken)) data-stoken="{{ $stoken }}" @endif></div>
 <noscript>
     <div style="width: 302px; height: 352px;">
         <div style="width: 302px; height: 352px; position: relative;">

--- a/src/views/captchav2.blade.php
+++ b/src/views/captchav2.blade.php
@@ -17,7 +17,7 @@ if ( ! function_exists('renderDataAttributes')) {
     </script>
 @endif
 <script src='https://www.google.com/recaptcha/api.js?render=onload{{ (isset($lang) ? '&hl='.$lang : '') }}'></script>
-<div class="g-recaptcha" data-sitekey="{{ $public_key }}" <?=renderDataAttributes($dataParams)?> @if(!empty($stoken)) data-stoken="{{ $stoken }}" @endif></div>
+<div class="g-recaptcha" data-sitekey="{{ $public_key }}" <?=renderDataAttributes($dataParams)?> @if(!empty($secure_token)) data-stoken="{{ $secure_token }}" @endif></div>
 <noscript>
     <div style="width: 302px; height: 352px;">
         <div style="width: 302px; height: 352px; position: relative;">


### PR DESCRIPTION
I've added a new option with backwards compatibility to use the Secure token option, as described here https://developers.google.com/recaptcha/docs/secure_token, in order to use it you have to add a data-stoken field.

Also updated the readme file in order to explain the new option and an example of the use.

Please feel free to edit, comment or let me know any change that you might feel necessary in order to merge.

Please note that as in the Issue [#85] @danieljausovec has helped me and provided a first draft of the code.