### PR TITLE
Added optional parameter "size" to allow use of both default and comp…

### DIFF
--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -9,7 +9,7 @@ class Recaptcha
 
     protected $config = [ ];
 
-    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback' ];
+    protected $dataParameterKeys = [ 'theme', 'type', 'callback', 'tabindex', 'expired-callback', 'size' ];
 
 
     public function __construct($service, $config)


### PR DESCRIPTION
Google added a new optional parameter for making the size of the recaptcha form smaller.

data-size = default | compact
