### PR TITLE
Added Laravel package discovery for laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Greggilbert\\Recaptcha\\RecaptchaServiceProvider"
+            ],
+            "aliases": {
+                "Recaptcha": "Greggilbert\\Recaptcha\\Facades\\Recaptcha"
+            }
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Added the Laravel package discovery stuff to composer.json for Laravel 5.5. This makes Laravel load in the providers and aliases needed for a package, which makes requiring them to be loaded in `config/app.php` not needed. (Still required for Laravel 5.4)

Signed-off-by: Kaleb Klein <klein.jae@gmail.com>